### PR TITLE
Remove rest-client, resolve tar.gz corruption problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'sinatra-contrib'
 gem 'sidekiq'
 gem 'rake'
 gem 'foodcritic'
-gem 'rest-client'
 gem 'dotenv'
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.3.6)
     ast (2.0.0)
     backports (3.6.0)
-    byebug (3.1.2)
+    byebug (3.2.0)
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
     celluloid (0.15.2)
@@ -18,24 +18,25 @@ GEM
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
     erubis (2.7.0)
-    foodcritic (3.0.3)
+    foodcritic (4.0.0)
       erubis
-      gherkin (~> 2.11.7)
-      nokogiri (~> 1.5.4)
+      gherkin (~> 2.11)
+      nokogiri (~> 1.5)
       rake
-      treetop (~> 1.4.10)
-      yajl-ruby (~> 1.1.0)
-    gherkin (2.11.8)
+      rufus-lru (~> 1.0)
+      treetop (~> 1.4)
+      yajl-ruby (~> 1.1)
+    gherkin (2.12.2)
       multi_json (~> 1.3)
     json (1.8.1)
     kgio (2.9.2)
-    mime-types (2.3)
+    mini_portile (0.6.0)
     minitest (5.4.0)
     minitest-focus (1.1.0)
       minitest (>= 4, < 6)
     multi_json (1.10.1)
-    netrc (0.7.7)
-    nokogiri (1.5.11)
+    nokogiri (1.6.3.1)
+      mini_portile (= 0.6.0)
     parser (2.2.0.pre.4)
       ast (>= 1.1, < 3.0)
       slop (~> 3.4, >= 3.4.5)
@@ -52,16 +53,13 @@ GEM
     redis (3.1.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
-    rest-client (1.7.2)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
-    rubocop (0.24.1)
-      json (>= 1.7.7, < 2)
-      parser (>= 2.2.0.pre.3, < 3.0)
+    rubocop (0.25.0)
+      parser (>= 2.2.0.pre.4, < 3.0)
       powerpack (~> 0.0.6)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.5.1)
+    rufus-lru (1.0.5)
     safe_yaml (1.0.3)
     sidekiq (3.2.2)
       celluloid (>= 0.15.2)
@@ -85,9 +83,8 @@ GEM
     slop (3.6.0)
     tilt (1.4.1)
     timers (1.1.0)
-    treetop (1.4.15)
-      polyglot
-      polyglot (>= 0.3.1)
+    treetop (1.5.3)
+      polyglot (~> 0.3)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -95,7 +92,7 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    yajl-ruby (1.1.0)
+    yajl-ruby (1.2.1)
     yard (0.8.7.4)
 
 PLATFORMS
@@ -109,7 +106,6 @@ DEPENDENCIES
   minitest-focus
   rack-test
   rake
-  rest-client
   rubocop
   sidekiq
   sinatra

--- a/lib/cookbook_artifact.rb
+++ b/lib/cookbook_artifact.rb
@@ -1,4 +1,3 @@
-require 'restclient'
 require 'rubygems/package'
 require 'foodcritic'
 
@@ -42,7 +41,15 @@ class CookbookArtifact
   #
   def download
     file = Tempfile.new('archive')
-    file << RestClient.get(url)
+
+    Net::HTTP.get_response URI.parse(url) do |response|
+      response.read_body do |segment|
+        file.write(segment)
+      end
+    end
+
+    file.close
+    file
   end
 
   #

--- a/lib/workers/cookbook_worker.rb
+++ b/lib/workers/cookbook_worker.rb
@@ -1,4 +1,3 @@
-require 'restclient'
 require 'sidekiq'
 
 class CookbookWorker
@@ -13,8 +12,8 @@ class CookbookWorker
     else
       feedback, status = cookbook.criticize
 
-      RestClient.post(
-        ENV['RESULTS_ENDPOINT'],
+      Net::HTTP.post_form(
+        URI.parse(ENV['RESULTS_ENDPOINT']),
         fieri_key: ENV['AUTH_TOKEN'],
         cookbook_name: params['cookbook_name'],
         cookbook_version: params['cookbook_version'],

--- a/tests/cookbook_artifact_test.rb
+++ b/tests/cookbook_artifact_test.rb
@@ -17,7 +17,7 @@ describe CookbookArtifact do
     end
 
     it 'assigns #archive' do
-      assert artifact.archive.is_a?(File)
+      assert artifact.archive.is_a?(Tempfile)
     end
 
     it 'assigns #directory' do


### PR DESCRIPTION
:fork_and_knife: rest-client for some reason is causing the corruption of some tar.gz files so this swaps out rest-client for the standard library Net::HTTP which appears to work with all of the test fixtures I've tried it with.
