### PR TITLE
Require Net::HTTP where used.

### DIFF
--- a/lib/cookbook_artifact.rb
+++ b/lib/cookbook_artifact.rb
@@ -1,3 +1,4 @@
+require 'net/http'
 require 'rubygems/package'
 require 'foodcritic'
 

--- a/lib/workers/cookbook_worker.rb
+++ b/lib/workers/cookbook_worker.rb
@@ -1,3 +1,4 @@
+require 'net/http'
 require 'sidekiq'
 
 class CookbookWorker


### PR DESCRIPTION
:fork_and_knife: Need to explicitly require Net::HTTP.
