### PR TITLE
Remove root job directory after CookbookArtifact instance is done with

### DIFF
--- a/lib/cookbook_artifact.rb
+++ b/lib/cookbook_artifact.rb
@@ -79,7 +79,7 @@ class CookbookArtifact
         file.close
       end
 
-      ObjectSpace.define_finalizer(self, proc { FileUtils.remove_dir(root) })
+      ObjectSpace.define_finalizer(self, proc { FileUtils.remove_dir("/tmp/cook/#{job_id}") })
 
       return root
     end


### PR DESCRIPTION
:fork_and_knife: Now that the cookbook artifact is nested in a folder named after the job id we'll need to remove that folder instead of the root archive directory.
