### PR TITLE
Make health status work

### DIFF
--- a/lib/server.rb
+++ b/lib/server.rb
@@ -38,15 +38,31 @@ class Server < Sinatra::Base
     sidekiq_health = { status: REACHABLE }
 
     begin
-      sidekiq_health.store(:jobs, CookbookWorker.jobs.size)
+      Sidekiq::Queue.new.tap do |queue|
+        sidekiq_health.store(:latency, queue.latency)
+        sidekiq_health.store(:queued_jobs, queue.size)
+      end
+
+      sidekiq_health.store(:active_workers, Sidekiq::Workers.new.size)
+      sidekiq_health.store(:dead_jobs, Sidekiq::DeadSet.new.size)
+      sidekiq_health.store(:retryable_jobs, Sidekiq::RetrySet.new.size)
+
+      Sidekiq::Stats.new.tap do |stats|
+        sidekiq_health.store(:total_processed, stats.processed)
+        sidekiq_health.store(:total_failed, stats.failed)
+      end
+
+      redis_info = Sidekiq.redis { |client| client.info }
+
+      %w(uptime_in_seconds connected_clients used_memory used_memory_peak).each do |key|
+        redis_health.store(key, redis_info.fetch(key, -1).to_i)
+      end
     rescue Redis::TimeoutError
       sidekiq_health.store(:status, UNKNOWN)
       redis_health.store(:status, UNKNOWN)
     rescue Redis::CannotConnectError
       sidekiq_health.store(:status, UNREACHABLE)
       redis_health.store(:status, UNREACHABLE)
-    rescue NoMethodError
-      sidekiq_health.store(:jobs, 0)
     end
 
     if redis_health.fetch(:status) == 'REACHABLE' &&
@@ -58,13 +74,8 @@ class Server < Sinatra::Base
 
     {
       'status' => status,
-      'sidekiq' => {
-        'status' => sidekiq_health.fetch(:status),
-        'jobs' => sidekiq_health.fetch(:jobs)
-      },
-      'redis' => {
-        'status' => redis_health.fetch(:status)
-      }
+      'sidekiq' => sidekiq_health,
+      'redis' => redis_health
     }.to_json
   end
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -11,18 +11,13 @@ require 'byebug'
 
 require_relative '../lib/app'
 
-#
-# In most cases, tests which queue jobs should
-# only care that the job was queued, and not care about the result.
-#
-Sidekiq::Testing.fake!
-
 module MiniTest
   class Spec
     include Rack::Test::Methods
 
     before do
       Sidekiq::Worker.clear_all
+      Sidekiq::Queue.new.clear
     end
 
     def app


### PR DESCRIPTION
:fork_and_knife: Calling `.jobs` on `CookbookWorker` was always resulting in a no method error and wasn't actually trying to communicate with redis, so if redis wasn't around it wouldn't throw an exception. This changes it to use the sidekiq API instead which will raise a redis exception if redis isn't up and running.
