### PR TITLE
Add CookbookArtifact#cleanup to remove unarchived directories

### DIFF
--- a/lib/cookbook_artifact.rb
+++ b/lib/cookbook_artifact.rb
@@ -35,6 +35,16 @@ class CookbookArtifact
     return result.to_s, result.failed?
   end
 
+  #
+  # Removes the unarchived directory returns nil if the directory
+  # doesn't exist.
+  #
+  # @return [Fixnum] the status code from the operation
+  #
+  def cleanup
+    FileUtils.remove_dir("/tmp/cook/#{job_id}", force: false)
+  end
+
   private
 
   #
@@ -78,8 +88,6 @@ class CookbookArtifact
         file << entry.read
         file.close
       end
-
-      ObjectSpace.define_finalizer(self, proc { FileUtils.remove_dir("/tmp/cook/#{job_id}") })
 
       return root
     end

--- a/lib/workers/cookbook_worker.rb
+++ b/lib/workers/cookbook_worker.rb
@@ -21,6 +21,8 @@ class CookbookWorker
         foodcritic_feedback: feedback,
         foodcritic_failure: status
       )
+
+      cookbook.cleanup
     end
   end
 end

--- a/tests/cookbook_artifact_test.rb
+++ b/tests/cookbook_artifact_test.rb
@@ -33,4 +33,11 @@ describe CookbookArtifact do
       assert_equal true, status
     end
   end
+
+  describe '#clean' do
+    it 'deletes the artifacts unarchived directory' do
+      artifact.cleanup
+      assert !Dir.exist?("/tmp/cook/#{artifact.job_id}")
+    end
+  end
 end

--- a/tests/workers/cookbook_worker_test.rb
+++ b/tests/workers/cookbook_worker_test.rb
@@ -2,8 +2,18 @@ require_relative '../test_helper'
 
 describe CookbookWorker do
   before do
+    #
+    # Stubs criticize for speed!
+    #
     CookbookArtifact.any_instance.stubs(:criticize).
       returns('FC023', true)
+
+    #
+    # Stubs cleanup so we can test the creation of unique
+    # directories.
+    #
+    CookbookArtifact.any_instance.stubs(:cleanup).
+      returns(0)
 
     stub_request(:get, 'http://example.com/apache.tar.gz').
       to_return(


### PR DESCRIPTION
:fork_and_knife: So we don't fill up fieri's disk with unarchived directory this adds a more explicit cleanup method that deletes the unarchived directory that gets called after posting the results to Supermarket.
